### PR TITLE
Styledhtml to pdf

### DIFF
--- a/server/models/transcript.py
+++ b/server/models/transcript.py
@@ -10,9 +10,6 @@ class TranscriptSettings(BaseModel):
     font: str = None
     line_height: str = None
     word_spacing: str = None
-    font_weight: str = None
-    font_style: str = None
-    text_decoration: str = None
 
 
 class TranscriptDataModel(BaseModel):

--- a/server/pdf_generator/generator.py
+++ b/server/pdf_generator/generator.py
@@ -18,9 +18,9 @@ def generate_pdf(html_data: str):
         html_data,
         False,
         options={
-            "margin-top": "0in",
-            "margin-bottom": "0in",
-            "margin-left": "0in",
-            "margin-right": "0in",
+            "margin-top": "1in",
+            "margin-bottom": "1in",
+            "margin-left": "1in",
+            "margin-right": "1in",
         },
     )

--- a/server/pdf_generator/templates/transcript.html
+++ b/server/pdf_generator/templates/transcript.html
@@ -25,15 +25,6 @@
       {%- if settings["word_spacing"] %}
       word-spacing: {{ settings.word_spacing }};
       {%- endif %}
-      {%- if settings["font_weight"] %}
-      font-weight: {{ settings.font_weight }};
-      {%- endif %}
-      {%- if settings["font_style"] %}
-      font-style: {{ settings.font_style }};
-      {%- endif %}
-      {%- if settings["text_decoration"] %}
-      text-decoration: {{ settings.text_decoration }};
-      {%- endif %}
     }
   </style>
 </head>

--- a/server/routes/pdf_routes.py
+++ b/server/routes/pdf_routes.py
@@ -42,5 +42,7 @@ async def generate_pdf_route(transcript_data: TranscriptDataModel):
 
     logging.info("Sending generated transcript to user...")
     response = Response(content=pdf_data, media_type="application/pdf", status_code=200)
-    response.headers["Content-Disposition"] = "inline"  # Set to inline instead of attachment
+    response.headers[
+        "Content-Disposition"
+    ] = "inline"  # Set to inline instead of attachment
     return response

--- a/server/routes/pdf_routes.py
+++ b/server/routes/pdf_routes.py
@@ -41,4 +41,6 @@ async def generate_pdf_route(transcript_data: TranscriptDataModel):
     pdf_data = generate_pdf(html_str)
 
     logging.info("Sending generated transcript to user...")
-    return Response(content=pdf_data, media_type="application/pdf", status_code=200)
+    response = Response(content=pdf_data, media_type="application/pdf", status_code=200)
+    response.headers["Content-Disposition"] = "inline"  # Set to inline instead of attachment
+    return response

--- a/transcript-client/package-lock.json
+++ b/transcript-client/package-lock.json
@@ -22,6 +22,7 @@
         "axios": "^1.6.2",
         "chakra-react-select": "^4.7.6",
         "draft-js": "^0.11.7",
+        "draft-js-export-html": "^1.4.1",
         "framer-motion": "^10.16.4",
         "react": "^18.2.0",
         "react-color-palette": "^7.1.0",
@@ -8360,6 +8361,27 @@
       "peerDependencies": {
         "react": ">=0.14.0",
         "react-dom": ">=0.14.0"
+      }
+    },
+    "node_modules/draft-js-export-html": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/draft-js-export-html/-/draft-js-export-html-1.4.1.tgz",
+      "integrity": "sha512-G4VGBSalPowktIE4wp3rFbhjs+Ln9IZ2FhXeHjsZDSw0a2+h+BjKu5Enq+mcsyVb51RW740GBK8Xbf7Iic51tw==",
+      "dependencies": {
+        "draft-js-utils": "^1.4.0"
+      },
+      "peerDependencies": {
+        "draft-js": ">=0.10.0",
+        "immutable": "3.x.x"
+      }
+    },
+    "node_modules/draft-js-utils": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/draft-js-utils/-/draft-js-utils-1.4.1.tgz",
+      "integrity": "sha512-xE81Y+z/muC5D5z9qWmKfxEW1XyXfsBzSbSBk2JRsoD0yzMGGHQm/0MtuqHl/EUDkaBJJLjJ2EACycoDMY/OOg==",
+      "peerDependencies": {
+        "draft-js": ">=0.10.0",
+        "immutable": "3.x.x"
       }
     },
     "node_modules/duplexer": {

--- a/transcript-client/package.json
+++ b/transcript-client/package.json
@@ -17,6 +17,7 @@
     "axios": "^1.6.2",
     "chakra-react-select": "^4.7.6",
     "draft-js": "^0.11.7",
+    "draft-js-export-html": "^1.4.1",
     "framer-motion": "^10.16.4",
     "react": "^18.2.0",
     "react-color-palette": "^7.1.0",

--- a/transcript-client/src/components/DisplayTranscript.tsx
+++ b/transcript-client/src/components/DisplayTranscript.tsx
@@ -15,6 +15,8 @@ import useEditorHook from "src/hooks/useEditor";
 const DisplayTranscript = () => {
   const {
     transcriptionData,
+    editorState,
+    setEditorState,
     fontSize,
     fontStyle,
     wordSpacing,
@@ -28,9 +30,7 @@ const DisplayTranscript = () => {
     isUnderline,
     setIsUnderline,
   } = useTranscription();
-  const [editorState, setEditorState] = useState(() =>
-  EditorState.createEmpty()
-  );
+
   const [initialContentState, setInitialContentState] = useState<EditorState | null>(null)
    
   const [currentStyleMap, setCurrentStyleMap] = useState(() =>

--- a/transcript-client/src/context/TranscriptionContext.tsx
+++ b/transcript-client/src/context/TranscriptionContext.tsx
@@ -3,8 +3,11 @@ import {
   TranscriptionContextType,
   TranscriptionData,
 } from "src/types/transcriptionDataTypes";
+import { EditorState } from 'draft-js';
 
 interface ExtendedTranscriptionContextType extends TranscriptionContextType {
+  editorState: EditorState;
+  setEditorState: React.Dispatch<React.SetStateAction<EditorState>>;
   audioFile: File | null;
   setAudioFile: React.Dispatch<React.SetStateAction<File | null>>;
 }
@@ -13,6 +16,8 @@ const defaultState: ExtendedTranscriptionContextType = {
   transcriptionData: null,
   setTranscriptionData: () => null,
   fontSize: "16px",
+  editorState: EditorState.createEmpty(),
+  setEditorState: () => {},
   setFontSize: () => {},
   fontColor: "#000000",
   setFontColor: () => {},
@@ -42,6 +47,7 @@ export const TranscriptionProvider = ({ children }: any) => {
   const [transcriptionData, setTranscriptionData] = useState<
     TranscriptionData[] | null
   >(null);
+  const [editorState, setEditorState] = useState(() => EditorState.createEmpty());
   const [fontSize, setFontSize] = useState<string>("16px");
   const [fontColor, setFontColor] = useState<string>("#000000");
   const [highlightColor, setHighlightColor] = useState<string>("");
@@ -66,6 +72,8 @@ export const TranscriptionProvider = ({ children }: any) => {
       value={{
         transcriptionData,
         setTranscriptionData,
+        editorState,
+        setEditorState,
         fontSize,
         setFontSize,
         fontStyle,

--- a/transcript-client/src/hooks/useDownloader.ts
+++ b/transcript-client/src/hooks/useDownloader.ts
@@ -8,25 +8,35 @@ interface Downloader {
 }
 
 const useDownloader = (): Downloader => {
-    // get the editor state and the styles from the context
     const { 
+      /* Case 1: get styledHtml from editorState*/
       editorState,
-      highlightColor,
-      fontColor, 
-      fontSize,
-      fontStyle, 
-      lineHeight, 
-      wordSpacing
+      /* Case 2: transcriptData + settings being passed to the server
+      transcriptData,
+      */
+      highlightColor,fontColor, fontSize,
+      fontStyle, lineHeight, wordSpacing
     } = useTranscription();
+    /* Case 1*/
     // use the useStyledHtmlExporter hook to get the styled html
     const styledHtml = useStyledHtmlExporter(editorState, {
-      fontSize,
-      fontStyle,
-      wordSpacing,
-      lineHeight,
-      fontColor,
-      highlightColor
+      fontSize,fontStyle,wordSpacing,
+      lineHeight,fontColor,highlightColor
     });
+    /* Case 2
+    // Settings object to be passed to server
+    const settings = {
+      bg_color: '',
+      font_color: fontColor || '',
+      font_size: fontSize || '', 
+      font: fontStyle || '',
+      line_height: lineHeight.toString() || '',
+      word_spacing: wordSpacing.toString()+'px' || '',
+      font_weight: 'normal',
+      font_style: 'normal',
+      text_decoration: 'none',
+    };
+    */
     // create a state to keep track of the loading state
     const [isLoading, setIsLoading] = useState(false);
     const generatePDF = async (): Promise<Blob> => {
@@ -40,7 +50,12 @@ const useDownloader = (): Downloader => {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
+            /* Case 1*/
             raw_html: styledHtml,
+            /* Case 2 
+            settings,
+            transcript: transcriptionData,
+            */
           }),
         });
   

--- a/transcript-client/src/hooks/useDownloader.ts
+++ b/transcript-client/src/hooks/useDownloader.ts
@@ -1,48 +1,46 @@
 import { useState } from 'react';
 import { useTranscription } from "src/context/TranscriptionContext";
+import useStyledHtmlExporter from 'src/hooks/useStyledHtmlExporter';
 
 interface Downloader {
   generatePDF: () => Promise<Blob>;
   isLoading: boolean;
 }
 
-
 const useDownloader = (): Downloader => {
+    // get the editor state and the styles from the context
     const { 
-      transcriptionData, fontColor, fontSize,
-      fontStyle, lineHeight, wordSpacing, 
-      isBold, isItalic, isUnderline 
+      editorState,
+      highlightColor,
+      fontColor, 
+      fontSize,
+      fontStyle, 
+      lineHeight, 
+      wordSpacing
     } = useTranscription();
-    //console.log('transcriptionData:', transcriptionData);
+    // use the useStyledHtmlExporter hook to get the styled html
+    const styledHtml = useStyledHtmlExporter(editorState, {
+      fontSize,
+      fontStyle,
+      wordSpacing,
+      lineHeight,
+      fontColor,
+      highlightColor
+    });
+    // create a state to keep track of the loading state
     const [isLoading, setIsLoading] = useState(false);
-    // TODO: Add more settings, figure out bg_color
-
-    const settings = {
-        bg_color: '',
-        font_color: fontColor || '',
-        font_size: fontSize || '', 
-        font: fontStyle || '',
-        line_height: lineHeight.toString() || '',
-        word_spacing: wordSpacing.toString()+'px' || '',
-        font_weight: 'normal',
-        font_style: 'normal',
-        text_decoration: 'none',
-        //font_weight: isBold ? 'bold': 'normal',
-        //font_style: isItalic ? 'italic': 'normal',
-        //text_decoration: isUnderline ? 'underline': 'none',
-      };
     const generatePDF = async (): Promise<Blob> => {
     setIsLoading(true);
       try {
+        // send the styled html to the server to generate the pdf
+        // TODO: replace the URL with the correct server URL
         const response = await fetch('http://localhost:8000/generate-pdf/', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
-            settings,
-            transcript: transcriptionData,
-            raw_html: '',
+            raw_html: styledHtml,
           }),
         });
   


### PR DESCRIPTION
This should now make the pdf look like the DisplayTranscript. 
**NOTE:** The highlight feature does not apply html tags around text, so text will not be highlighted.

**(server) Changes to TranscriptSettings and templates/transcript.html:**
- removed bold, italics, underline (not supposed to affect entire text)

**(client) Changes to TranscriptionContext structure:**
- added editorState and it's EditorState import
- removed editorState being initialized within DisplayTranscript
- DisplayTranscript now uses editorState from useTranscription()

**(client) Changes to useDownloader:**
- Added editorState
- Removed transcriptData
- removed settings component
- body of fetch request switched from transcriptData+settings to styledHtml
